### PR TITLE
Override LD_PRELOAD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Ignore IDE specific files
+/.idea
+
+# simplecov reports
+coverage
+
+.pryrc
+.DS_Store
+.generators
+.rakeTasks

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test/dummy/**/*
 gemfiles/*.lock
 .DS_Store
 .rakeTasks
+.idea

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,11 @@
+# Docker
+
+You can pull the image
+```shell
+docker pull learningtapestry/wicked_pdf:ruby-2.7.7
+```
+
+Or build it
+```shell
+docker build -t learningtapestry/wicked_pdf:ruby-2.7.7 .
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.7.7
+
+ENV APP_PATH /app/
+ENV LANG C.UTF-8
+
+WORKDIR $APP_PATH
+
+# Add codebase
+ADD . $APP_PATH
+
+# Install gems
+RUN gem install bundler \
+    && bundle install \
+    && rm -rf /usr/local/bundle/cache/*.gem \
+    && find /usr/local/bundle/gems/ -name "*.c" -delete \
+    && find /usr/local/bundle/gems/ -name "*.o" -delete

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -65,7 +65,13 @@ class WickedPdf # rubocop:disable Metrics/ClassLength:
     if track_progress?(options)
       invoke_with_progress(command, options)
     else
-      err = Open3.popen3(*command) do |_stdin, _stdout, stderr|
+      env =
+        if WickedPdf.config.key?(:ld_preload_override)
+          { "LD_PRELOAD" => WickedPdf.config[:ld_preload_override] }
+        else
+          {}
+        end
+      err = Open3.popen3(env, *command) do |_stdin, _stdout, stderr|
         stderr.read
       end
     end


### PR DESCRIPTION
1. There can be situations when LD_PRELOAD is already set. Then puppeteer will raise _Segmentation Fault_ as chromium already uses its own allocator.

  In that case we should override LD_PRELOAD and nulify it:

```ruby
WickedPdf.config = {
  exe_path: ENV.fetch('WKHTMLTOPDF_PATH', '/usr/local/bin/wkhtmltopdf'),
  puppeteer_timeout: ENV.fetch('PUPPETEER_TIMEOUT', 30_000),
  use_puppeteer: true,
  ld_preload_override: ''
}
```

2. Add simple Docker support mostly for convient development