### PR TITLE
Fix puppeter exec path

### DIFF
--- a/lib/wicked_pdf/progress.rb
+++ b/lib/wicked_pdf/progress.rb
@@ -10,7 +10,7 @@ class WickedPdf
     def invoke_with_progress(command, options)
       output = []
       begin
-        PTY.spawn(command.join(' ')) do |stdout, _stdin, pid|
+        PTY.spawn(ENV, command.join(' ')) do |stdout, _stdin, pid|
           begin
             stdout.sync
             stdout.each_line("\r") do |line|


### PR DESCRIPTION
This change allows passing env vars to the puppeteer process.
So, this way We can pass the:

```
PUPPETEER_EXECUTABLE_PATH="/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
```

I need this change because there is no `chromium-browser` binary to mac m1.
https://learningtapestry.airbrake.io/projects/304271/groups/3468032122005552643